### PR TITLE
Fix login redirect to dashboard

### DIFF
--- a/src/views/js/login.js
+++ b/src/views/js/login.js
@@ -16,7 +16,7 @@ loginForm.addEventListener('submit', async (event) => {
     if (response.ok) {
       const { token } = await response.json();
       localStorage.setItem('token', token);
-      window.location.href = '/src/views/pages/dashboard.html '; // Redirecionamento corrigido
+      window.location.href = '/dashboard'; // Redireciona para o dashboard
     } else {
       const error = await response.json();
       alert(`Erro: ${error.message}`);


### PR DESCRIPTION
## Summary
- update the login redirect to point to /dashboard without the trailing space
- confirm the backend already exposes the /dashboard route that serves the dashboard page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9785c9c5c8327a5dca602ca2258c8