### PR TITLE
Hash user passwords with bcrypt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcrypt": "^5.1.1",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "nodemon app.js"
   },
   "dependencies": {
+    "bcrypt": "^5.1.1",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,5 +1,8 @@
 const User = require('../models/User');
 const jwt = require('jsonwebtoken');
+const bcrypt = require('bcrypt');
+
+const SALT_ROUNDS = 10;
 
 // Função para gerar o token JWT
 const generateToken = (user) => {
@@ -25,10 +28,12 @@ exports.register = async (req, res) => {
     }
 
     // Cria o novo usuário
+    const hashedPassword = await bcrypt.hash(senha, SALT_ROUNDS);
+
     const newUser = new User({
       nome,
       email,
-      senha,
+      senha: hashedPassword,
     });
 
     await newUser.save();
@@ -51,7 +56,8 @@ exports.login = async (req, res) => {
     }
 
     // Compara a senha fornecida com a senha armazenada
-    if (senha!== user.senha) {
+    const isPasswordValid = await bcrypt.compare(senha, user.senha);
+    if (!isPasswordValid) {
       return res.status(401).json({ message: 'Credenciais inválidas' });
     }
 

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,4 +1,8 @@
 const mongoose = require('mongoose');
+const bcrypt = require('bcrypt');
+
+const SALT_ROUNDS = 10;
+const BCRYPT_HASH_REGEX = /^\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53}$/;
 
 const UserSchema = new mongoose.Schema({
   nome: {
@@ -18,6 +22,57 @@ const UserSchema = new mongoose.Schema({
     type: Boolean,
     default: false, // Define o valor padrão como false
   },
+});
+
+UserSchema.pre('save', async function (next) {
+  if (!this.isModified('senha')) {
+    return next();
+  }
+
+  if (BCRYPT_HASH_REGEX.test(this.senha)) {
+    return next();
+  }
+
+  try {
+    this.senha = await bcrypt.hash(this.senha, SALT_ROUNDS);
+    next();
+  } catch (error) {
+    next(error);
+  }
+});
+
+UserSchema.pre('findOneAndUpdate', async function (next) {
+  const update = this.getUpdate();
+  if (!update) {
+    return next();
+  }
+
+  const senha =
+    update.senha ??
+    (update.$set && Object.prototype.hasOwnProperty.call(update.$set, 'senha')
+      ? update.$set.senha
+      : undefined);
+
+  if (!senha || BCRYPT_HASH_REGEX.test(senha)) {
+    return next();
+  }
+
+  try {
+    const hashedPassword = await bcrypt.hash(senha, SALT_ROUNDS);
+
+    if (update.senha) {
+      update.senha = hashedPassword;
+    }
+
+    if (update.$set && Object.prototype.hasOwnProperty.call(update.$set, 'senha')) {
+      update.$set.senha = hashedPassword;
+    }
+
+    this.setUpdate(update);
+    next();
+  } catch (error) {
+    next(error);
+  }
 });
 
 const User = mongoose.model('User', UserSchema);


### PR DESCRIPTION
## Summary
- hash passwords during registration and enforce secure comparisons during login using bcrypt
- add automatic password hashing middleware on the User model to protect updates
- declare the bcrypt dependency for the project

## Testing
- npm install *(fails in container: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c977e2c9b88327b334bc54a89d417f