### PR TITLE
Remove duplicate admin route registration

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,7 +34,6 @@ app.use('/auth', authRoutes);
 app.use('/tickets', ticketsRoutes);
 app.use('/vendas', vendasRoutes);
 app.use('/users', usersRoutes);
-app.use('/admin', authenticateToken, isAdmin, require('./src/routes/admin.routes'));
 
 // 5. Rotas de Admin (requer autenticação e verificação de administrador)
 app.use('/admin', authenticateToken, isAdmin, require('./src/routes/admin.routes'));


### PR DESCRIPTION
## Summary
- remove the duplicate `/admin` route registration so the admin middleware chain is only applied once

## Testing
- MONGO_URI=mongodb://127.0.0.1:27017/test node app.js
- curl -I http://127.0.0.1:3000/


------
https://chatgpt.com/codex/tasks/task_e_68c978138a0c8327a14d758b92b65f54